### PR TITLE
make url/patterns import work with Django 1.6

### DIFF
--- a/asnsreceiver/urls.py
+++ b/asnsreceiver/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('asnsreceiver.views',
     url(r'^asns/notify/$', 'receive_notification', name='asns-receive-notification'),


### PR DESCRIPTION
this works both with 1.5 and 1.6
